### PR TITLE
Update caroufredsel-rails.gemspec

### DIFF
--- a/caroufredsel-rails.gemspec
+++ b/caroufredsel-rails.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.version       = Caroufredsel::Rails::VERSION
   gem.authors       = ["John Bintz"]
   gem.email         = ["john@coswellproductions.com"]
-  gem.description   = %q{TODO: Write a gem description}
-  gem.summary       = %q{TODO: Write a gem summary}
+  gem.description   = "Use caroufredsel with rails. It's pretty good."
+  gem.summary       = "Caroufredsel with rails"
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
ruby 2.0 in Ubuntu 14.04.2 doesn't like it when "TODOs" are in the gemspec description. This minor change addresses this problem.
